### PR TITLE
Modifications to match Remote's styleguide

### DIFF
--- a/docs/module_directives.md
+++ b/docs/module_directives.md
@@ -39,12 +39,15 @@ Modules directives are sorted into the following order:
 
 * `@shortdoc`
 * `@moduledoc` (adds `@moduledoc false`)
-* `@behaviour`
 * `use`
 * `import` (sorted alphabetically)
 * `alias` (sorted alphabetically)
 * `require` (sorted alphabetically)
+* `@behaviour`
 * everything else (order unchanged)
+
+The heuristic here is that docs generally go first, followed by directives in order from most impactful on the module to
+least impactful on the module.
 
 ### Before
 
@@ -98,8 +101,6 @@ defmodule Foo do
              |> File.read!()
              |> String.split("<!-- MDOC !-->")
              |> Enum.fetch!(1)
-  @behaviour Chaotic
-  @behaviour Lawful
 
   use B
   use A.A
@@ -107,13 +108,16 @@ defmodule Foo do
   import A.A
   import C
 
+  require A
+  require B
+  require C
+
   alias A.A
   alias C.C
   alias D.D
 
-  require A
-  require B
-  require C
+  @behaviour Chaotic
+  @behaviour Lawful
 
   def c(x), do: y
 
@@ -136,6 +140,7 @@ If any line previously relied on an alias, the alias is fully expanded when it i
 # Given
 alias Foo.Bar
 import Bar
+
 # Styled
 import Foo.Bar
 

--- a/lib/alias_env.ex
+++ b/lib/alias_env.ex
@@ -14,6 +14,7 @@ defmodule Styler.AliasEnv do
 
       %{:Bar => [:Foo, :Bar]}
   """
+
   def define(env \\ %{}, ast)
 
   def define(env, asts) when is_list(asts), do: Enum.reduce(asts, env, &define(&2, &1))

--- a/lib/style.ex
+++ b/lib/style.ex
@@ -31,7 +31,7 @@ defmodule Styler.Style do
   """
   @callback run(Zipper.t(), context()) :: {Zipper.command(), Zipper.t(), context()}
 
-  @doc "Recursively sets `:line` meta to `line`. Deletes `:newlines` unless `delete_lines: false` is passed"
+  @doc "Recursively sets `:line` meta to `line`. Deletes `:newlines` unless `delete_newlines: false` is passed"
   def set_line(ast_node, line, opts \\ []) do
     set_line = fn _ -> line end
 
@@ -162,7 +162,7 @@ defmodule Styler.Style do
   def reset_newlines([node], acc), do: Enum.reverse([set_newlines(node, 2) | acc])
   def reset_newlines([node | nodes], acc), do: reset_newlines(nodes, [set_newlines(node, 1) | acc])
 
-  defp set_newlines({directive, meta, children}, newline) do
+  def set_newlines({directive, meta, children}, newline) do
     updated_meta = Keyword.update(meta, :end_of_expression, [newlines: newline], &Keyword.put(&1, :newlines, newline))
     {directive, updated_meta, children}
   end

--- a/lib/style.ex
+++ b/lib/style.ex
@@ -162,7 +162,7 @@ defmodule Styler.Style do
   def reset_newlines([node], acc), do: Enum.reverse([set_newlines(node, 2) | acc])
   def reset_newlines([node | nodes], acc), do: reset_newlines(nodes, [set_newlines(node, 1) | acc])
 
-  def set_newlines({directive, meta, children}, newline) do
+  defp set_newlines({directive, meta, children}, newline) do
     updated_meta = Keyword.update(meta, :end_of_expression, [newlines: newline], &Keyword.put(&1, :newlines, newline))
     {directive, updated_meta, children}
   end

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -33,11 +33,11 @@ defmodule Styler.Style.ModuleDirectives do
 
     * `@shortdoc`
     * `@moduledoc`
-    * `@behaviour`
     * `use`
     * `import`
     * `alias`
     * `require`
+    * `@behaviour`
     * everything else (unchanged)
   """
 
@@ -216,11 +216,11 @@ defmodule Styler.Style.ModuleDirectives do
       [
         acc.shortdoc,
         acc.moduledoc,
-        acc.behaviour,
         acc.use,
         acc.import,
         acc.require,
-        acc.alias
+        acc.alias,
+        acc.behaviour
       ]
       |> Stream.concat()
       |> Style.fix_line_numbers(List.first(nondirectives))

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -125,8 +125,6 @@ defmodule Styler.Style.ModuleDirectives do
     if Enum.empty?(attrs) do
       {ast, acc}
     else
-      # TODO: Instead of use, check that we're in a quote
-
       Macro.prewalk(ast, acc, fn
         {:@, _m, [{attr, _, _} = var]} = ast, acc ->
           if attr in attrs do

--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -35,8 +35,8 @@ defmodule Styler.Style.ModuleDirectives do
     * `@moduledoc`
     * `use`
     * `import`
-    * `alias`
     * `require`
+    * `alias`
     * `@behaviour`
     * everything else (unchanged)
   """

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -221,12 +221,33 @@ defmodule Styler.Style.SingleNode do
     end)
   end
 
-  defp delimit(token), do: token |> String.to_charlist() |> remove_underscores([]) |> add_underscores([])
+  defp delimit(token) do
+    chars = String.to_charlist(token)
+
+    result =
+      case Enum.reverse(chars) do
+        [hundredth, tenth, ?_ | rest] when is_integer(tenth) and is_integer(hundredth) ->
+          delimited = rest |> Enum.reverse() |> fix_underscores()
+
+          delimited ++ [?_, tenth, hundredth]
+
+        _other_num ->
+          fix_underscores(chars)
+      end
+
+    to_string(result)
+  end
+
+  defp fix_underscores(num_tokens) do
+    num_tokens
+    |> remove_underscores([])
+    |> add_underscores([])
+  end
 
   defp remove_underscores([?_ | rest], acc), do: remove_underscores(rest, acc)
   defp remove_underscores([digit | rest], acc), do: remove_underscores(rest, [digit | acc])
   defp remove_underscores([], reversed_list), do: reversed_list
 
   defp add_underscores([a, b, c, d | rest], acc), do: add_underscores([d | rest], [?_, c, b, a | acc])
-  defp add_underscores(reversed_list, acc), do: reversed_list |> Enum.reverse(acc) |> to_string()
+  defp add_underscores(reversed_list, acc), do: Enum.reverse(reversed_list, acc)
 end

--- a/lib/style_error.ex
+++ b/lib/style_error.ex
@@ -12,6 +12,7 @@ defmodule Styler.StyleError do
   @moduledoc """
   Wraps errors raised by Styles during tree traversal.
   """
+
   defexception [:exception, :style, :file]
 
   def message(%{exception: exception, style: style, file: file}) do

--- a/lib/styler.ex
+++ b/lib/styler.ex
@@ -12,6 +12,7 @@ defmodule Styler do
   @moduledoc """
   Styler is a formatter plugin with stronger opinions on code organization, multi-line defs and other code-style matters.
   """
+
   @behaviour Mix.Tasks.Format
 
   alias Mix.Tasks.Format

--- a/lib/styler/config.ex
+++ b/lib/styler/config.ex
@@ -10,6 +10,7 @@
 
 defmodule Styler.Config do
   @moduledoc false
+
   @key __MODULE__
 
   @stdlib MapSet.new(~w(

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -23,6 +23,7 @@ defmodule Styler.Zipper do
   2-tuple where the first element is the focus and the second element is the
   metadata/context. The metadata is `nil` when the focus is the topmost node
   """
+
   import Kernel, except: [node: 1]
 
   @type tree :: Macro.t()

--- a/test/style/configs_test.exs
+++ b/test/style/configs_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.ConfigsTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true, filename: "config/config.exs"
 
   alias Styler.Style.Configs

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -83,12 +83,8 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
-
-        alias A.B.C
-
         defmodule B do
-          @moduledoc false
+          alias A.B.C
 
           C.f()
           C.f()
@@ -112,8 +108,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule Timely do
-        @moduledoc false
-
         use A.B.C
 
         import A.B.C
@@ -158,31 +152,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
     )
   end
 
-  test "lifts in modules with only-child bodies" do
-    assert_style(
-      """
-      defmodule A do
-        def lift_me() do
-          A.B.C.foo()
-          A.B.C.baz()
-        end
-      end
-      """,
-      """
-      defmodule A do
-        @moduledoc false
-
-        alias A.B.C
-
-        def lift_me do
-          C.foo()
-          C.baz()
-        end
-      end
-      """
-    )
-  end
-
   test "re-sorts requires after lifting" do
     assert_style(
       """
@@ -195,8 +164,6 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """,
       """
       defmodule A do
-        @moduledoc false
-
         require B
         require C
 

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true
 
   test "lifts aliases repeated >=2 times from 3 deep" do
@@ -83,10 +84,12 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
+
         alias A.B.C
 
         defmodule B do
           @moduledoc false
+
           C.f()
           C.f()
         end
@@ -110,13 +113,14 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule Timely do
         @moduledoc false
+
         use A.B.C
 
         import A.B.C
 
-        alias A.B.C
-
         require C
+
+        alias A.B.C
 
         def foo do
           C.bop()
@@ -167,6 +171,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
+
         alias A.B.C
 
         def lift_me do
@@ -191,10 +196,11 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       """
       defmodule A do
         @moduledoc false
-        alias A.B.C
 
         require B
         require C
+
+        alias A.B.C
 
         C.foo()
       end
@@ -234,9 +240,10 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         A.B.C.f()
         """,
         """
-        alias A.B.C
         # Foo is my fave
         require Foo
+
+        alias A.B.C
 
         C.f()
         C.f()
@@ -319,6 +326,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         defmodule C do
           @moduledoc false
+
           A.B.C.f()
         end
 
@@ -375,6 +383,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         defmodule A.B.C do
           @moduledoc false
+
           :body
         end
 
@@ -399,6 +408,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
       assert_style """
       defmodule A do
         @moduledoc false
+
         defmacro __using__(_) do
           quote do
             A.B.C.f()

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -111,9 +111,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
                      |> String.split("<!-- MDOC !-->")
                      |> Enum.fetch!(1)
 
-          @behaviour Chaotic
-          @behaviour Lawful
-
           use B
           use A.A
 
@@ -127,6 +124,9 @@ defmodule Styler.Style.ModuleDirectivesTest do
           alias A.A
           alias C.C
           alias D.D
+
+          @behaviour Chaotic
+          @behaviour Lawful
 
           def c(x), do: y
 
@@ -427,8 +427,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
       defmodule MyModule do
         @moduledoc "Implements \#{A.B.C.foo()}!"
 
-        @behaviour G.H.C
-
         use SomeMacro, with: Z.X.C
 
         import A.B
@@ -439,6 +437,8 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias D.F.C
         alias G.H.C
         alias Z.X.C
+
+        @behaviour G.H.C
       end
       """
     )
@@ -461,29 +461,6 @@ defmodule Styler.Style.ModuleDirectivesTest do
           @moduledoc make_pretty_docs(library_options)
 
           use OptionsMagic, my_opts: library_options
-
-          @library_options library_options
-        end
-        """
-      )
-    end
-
-    test "works with `quote`" do
-      assert_style(
-        """
-        quote do
-          @library_options [...]
-          @moduledoc make_pretty_docs(@library_options)
-          use OptionsMagic, my_opts: @library_options
-        end
-        """,
-        """
-        library_options = [...]
-
-        quote do
-          @moduledoc make_pretty_docs(library_options)
-
-          use OptionsMagic, my_opts: unquote(library_options)
 
           @library_options library_options
         end

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -300,6 +300,14 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("-123456728.0001", "-123_456_728.0001")
     end
 
+    test "if the last two numbers are separated by an underscore (cents style), leave the cents style in place" do
+      assert_style("1_00", "1_00")
+      assert_style("10_00", "10_00")
+      assert_style("97_8", "97_8")
+      assert_style("18000_76", "18_000_76")
+      assert_style("1020000_99", "1_020_000_99")
+    end
+
     test "stays away from small numbers, strings and science" do
       assert_style("1234")
       assert_style("9999")

--- a/test/style/styles_test.exs
+++ b/test/style/styles_test.exs
@@ -12,6 +12,7 @@ defmodule Styler.Style.StylesTest do
   @moduledoc """
   A place for tests that make sure our styles play nicely with each other
   """
+
   use Styler.StyleCase, async: true
 
   describe "pipes + defs" do

--- a/test/support/style_case.ex
+++ b/test/support/style_case.ex
@@ -12,6 +12,7 @@ defmodule Styler.StyleCase do
   @moduledoc """
   Helpers around testing Style rules.
   """
+
   use ExUnit.CaseTemplate
 
   using options do


### PR DESCRIPTION
Makes a few modifications to Styler to ensure the rules fit our styleguide, including:

* Changing the ordering of module directives: `@moduledoc > use > import > require > alias > @behaviour > everything else`.
* Allowing for underscore separated integers using the cents style: e.g. `1_000_00` is now allowed, whereas previously Styler would convert this to `100_000`.
* Automatically adds a newline after all `@moduledoc`s.
* Removes logic that automatically adds `@moduledoc false` to files without moduledocs. It is better that the developer decide for themselves whether they need to add a moduledoc or wish to not add one.