### PR TITLE
Remove implicit try rule

### DIFF
--- a/docs/styles.md
+++ b/docs/styles.md
@@ -96,45 +96,6 @@ The examples below use `DateTime.compare/2`, but the same is also done for `Naiv
 | `DateTime.compare(start, end_date) == :gt` | `DateTime.after?(start, end_date)` |
 | `DateTime.compare(start, end_date) == :lt` | `DateTime.before?(start, end_date)` |
 
-## Implicit Try
-
-Styler will rewrite functions whose entire body is a try/do to instead use the implicit try syntax, per Credo's `Credo.Check.Readability.PreferImplicitTry`
-
-The following example illustrates the most complex case, but Styler happily handles just basic try do/rescue bodies just as easily.
-
-### Before
-
-```elixir
-def foo() do
-  try do
-    uh_oh()
-  rescue
-    exception -> {:error, exception}
-  catch
-    :a_throw -> {:error, :threw!}
-  else
-    try_has_an_else_clause? -> {:did_you_know, try_has_an_else_clause?}
-  after
-    :done
-  end
-end
-```
-
-### After
-
-```elixir
-def foo() do
-  uh_oh()
-rescue
-  exception -> {:error, exception}
-catch
-  :a_throw -> {:error, :threw!}
-else
-  try_has_an_else_clause? -> {:did_you_know, try_has_an_else_clause?}
-after
-  :done
-end
-```
 
 ## Remove parenthesis from 0-arity function & macro definitions
 

--- a/lib/style/single_node.ex
+++ b/lib/style/single_node.ex
@@ -165,12 +165,9 @@ defmodule Styler.Style.SingleNode do
   defp style({def, dm, [{fun, funm, []} | rest]}) when def in ~w(def defp)a and is_atom(fun),
     do: style({def, dm, [{fun, Keyword.delete(funm, :closing), nil} | rest]})
 
-  # `Credo.Check.Readability.PreferImplicitTry`
-  defp style({def, dm, [head, [{_, {:try, _, [try_children]}}]]}) when def in ~w(def defp)a,
-    do: style({def, dm, [head, try_children]})
-
-  defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a,
-    do: {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}
+  defp style({def, dm, [{fun, funm, params} | rest]}) when def in ~w(def defp)a do
+    {def, dm, [{fun, funm, put_matches_on_right(params)} | rest]}
+  end
 
   # `Enum.reverse(foo) ++ bar` => `Enum.reverse(foo, bar)`
   defp style({:++, _, [{{:., _, [{_, _, [:Enum]}, :reverse]} = reverse, r_meta, [lhs]}, rhs]}),

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -136,41 +136,6 @@ defmodule Styler.Style.SingleNodeTest do
       assert_style("def metaprogramming(foo)(), do: bar")
     end
 
-    test "prefers implicit try" do
-      for def_style <- ~w(def defp) do
-        assert_style(
-          """
-          #{def_style} foo() do
-            :ok
-          rescue
-            exception -> :excepted
-          catch
-            :a_throw -> :thrown
-          else
-            i_forgot -> i_forgot.this_could_happen
-          after
-            :done
-          end
-          """,
-          """
-          #{def_style} foo do
-            try do
-              :ok
-            rescue
-              exception -> :excepted
-            catch
-              :a_throw -> :thrown
-            else
-              i_forgot -> i_forgot.this_could_happen
-            after
-              :done
-            end
-          end
-          """
-        )
-      end
-    end
-
     test "doesnt rewrite when there are other things in the body" do
       assert_style("""
       def foo do

--- a/test/style/single_node_test.exs
+++ b/test/style/single_node_test.exs
@@ -141,6 +141,19 @@ defmodule Styler.Style.SingleNodeTest do
         assert_style(
           """
           #{def_style} foo() do
+            :ok
+          rescue
+            exception -> :excepted
+          catch
+            :a_throw -> :thrown
+          else
+            i_forgot -> i_forgot.this_could_happen
+          after
+            :done
+          end
+          """,
+          """
+          #{def_style} foo do
             try do
               :ok
             rescue
@@ -152,19 +165,6 @@ defmodule Styler.Style.SingleNodeTest do
             after
               :done
             end
-          end
-          """,
-          """
-          #{def_style} foo do
-            :ok
-          rescue
-            exception -> :excepted
-          catch
-            :a_throw -> :thrown
-          else
-            i_forgot -> i_forgot.this_could_happen
-          after
-            :done
           end
           """
         )


### PR DESCRIPTION
We like using `try` explicitly since `try` use should be obvious and rare.