### PR TITLE
Allow explicit if-else `nil` return

### DIFF
--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -182,10 +182,6 @@ defmodule Styler.Style.Blocks do
       [negator, [do_block]] when is_negator(negator) ->
         zipper |> Zipper.replace({:unless, m, [invert(negator), [do_block]]}) |> run(ctx)
 
-      # drop `else: nil`
-      [head, [do_block, {_, {:__block__, _, [nil]}}]] ->
-        {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}
-
       [head, [do_, else_]] ->
         if Style.max_line(do_) > Style.max_line(else_) do
           # we inverted the if/else blocks of this `if` statement in a previous pass (due to negators or unless)

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -66,9 +66,10 @@ defmodule Styler.Style.BlocksTest do
         if foo do
           # a
           :ok
+        else
+          # b
+          nil
         end
-
-        # b
         """
       )
 
@@ -82,6 +83,8 @@ defmodule Styler.Style.BlocksTest do
         """
         if foo do
           :ok
+        else
+          nil
         end
         """
       )
@@ -770,16 +773,6 @@ defmodule Styler.Style.BlocksTest do
   end
 
   describe "if/unless" do
-    test "drops if else nil" do
-      assert_style("if a, do: b, else: nil", "if a, do: b")
-
-      assert_style("if a do b else nil end", """
-      if a do
-        b
-      end
-      """)
-    end
-
     test "if not => unless" do
       assert_style("if not x, do: y", "unless x, do: y")
       assert_style("if !x, do: y", "unless x, do: y")


### PR DESCRIPTION
We find that explicitly writing out `else` `nil` is clearer and more explicit than the explicit `if` behavior that returns `nil` when the condition is false.