### PR TITLE
Disable `case` to `if` conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,38 +79,6 @@ Styler [will not add configuration](https://github.com/adobe/elixir-styler/pull/
 
 Ultimately Styler is @adobe's internal tool that we're happy to share with the world. We're delighted if you like it as is, and just as excited if it's a starting point for you to make something even better for yourself.
 
-## !Styler can change the behaviour of your program!
-
-The best example of the way in which Styler changes the meaning of your code is the following rewrite:
-```elixir
-# Before: this case statement...
-case foo do
-  true -> :ok
-  false -> :error
-end
-
-# After: ... is rewritten by Styler to be an if statement!.
-if foo do
-  :ok
-else
-  :error
-end
-```
-
-These programs are not semantically equivalent. The former would raise if `foo` returned any value other than `true` or `false`, while the latter blissfully completes.
-
-However, Styler is about _style_, and the `if` statement is (in our opinion) of much better style. If the exception behaviour was intentional on the code author's part, they should have written the program like this:
-
-```elixir
-case foo do
-  true -> :ok
-  false -> :error
-  other -> raise "expected `true` or `false`, got: #{inspect other}"
-end
-```
-
-Also good style! But Styler assumes that most of the time people just meant the `if` equivalent of the code, and so makes that change. If issues like this bother you, Styler probably isn't the tool you're looking for.
-
 ## Thanks & Inspiration
 
 ### [Sourceror](https://github.com/doorgan/sourceror/)

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -17,9 +17,7 @@ defmodule Styler.Style.Blocks do
   * Credo.Check.Consistency.ParameterPatternMatching
   * Credo.Check.Readability.LargeNumbers
   * Credo.Check.Readability.ParenthesesOnZeroArityDefs
-  * Credo.Check.Readability.PreferImplicitTry
   * Credo.Check.Readability.WithSingleClause
-  * Credo.Check.Refactor.CaseTrivialMatches
   * Credo.Check.Refactor.CondStatements
   * Credo.Check.Refactor.RedundantWithClauseResult
   * Credo.Check.Refactor.WithClauses
@@ -34,14 +32,14 @@ defmodule Styler.Style.Blocks do
 
   # case statement with exactly 2 `->` cases
   # rewrite to `if` if it's any of 3 trivial cases
-  def run({{:case, _, [head, [{_, [{:->, _, [[lhs_a], a]}, {:->, _, [[lhs_b], b]}]}]]}, _} = zipper, ctx) do
-    case {lhs_a, lhs_b} do
-      {{_, _, [true]}, {_, _, [false]}} -> if_ast(zipper, head, a, b, ctx)
-      {{_, _, [true]}, {:_, _, _}} -> if_ast(zipper, head, a, b, ctx)
-      {{_, _, [false]}, {_, _, [true]}} -> if_ast(zipper, head, b, a, ctx)
-      _ -> {:cont, zipper, ctx}
-    end
-  end
+  # def run({{:case, _, [head, [{_, [{:->, _, [[lhs_a], a]}, {:->, _, [[lhs_b], b]}]}]]}, _} = zipper, ctx) do
+  #   case {lhs_a, lhs_b} do
+  #     {{_, _, [true]}, {_, _, [false]}} -> if_ast(zipper, head, a, b, ctx)
+  #     {{_, _, [true]}, {:_, _, _}} -> if_ast(zipper, head, a, b, ctx)
+  #     {{_, _, [false]}, {_, _, [true]}} -> if_ast(zipper, head, b, a, ctx)
+  #     _ -> {:cont, zipper, ctx}
+  #   end
+  # end
 
   # Credo.Check.Refactor.CondStatements
   def run({{:cond, _, [[{_, [{:->, _, [[head], a]}, {:->, _, [[{:__block__, _, [truthy]}], b]}]}]]}, _} = zipper, ctx)

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -11,237 +11,6 @@
 defmodule Styler.Style.BlocksTest do
   use Styler.StyleCase, async: true
 
-  describe "case to if" do
-    test "rewrites case true false to if else" do
-      assert_style(
-        """
-        case foo do
-          # a
-          true -> :ok
-          # b
-          false -> :error
-        end
-        """,
-        """
-        if foo do
-          # a
-          :ok
-        else
-          # b
-          :error
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          # a
-          true -> :ok
-          # b
-          _ -> :error
-        end
-        """,
-        """
-        if foo do
-          # a
-          :ok
-        else
-          # b
-          :error
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          # a
-          true -> :ok
-          # b
-          false -> nil
-        end
-        """,
-        """
-        if foo do
-          # a
-          :ok
-        else
-          # b
-          nil
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          true -> :ok
-          _ -> nil
-        end
-        """,
-        """
-        if foo do
-          :ok
-        else
-          nil
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          true -> :ok
-          false ->
-            Logger.warning("it's false")
-            nil
-        end
-        """,
-        """
-        if foo do
-          :ok
-        else
-          Logger.warning("it's false")
-          nil
-        end
-        """
-      )
-    end
-
-    test "block swapping comments" do
-      assert_style(
-        """
-        case foo do
-          false ->
-            # a
-            :error
-          true ->
-            # b
-            :ok
-        end
-        """,
-        """
-        if foo do
-          # b
-          :ok
-        else
-          # a
-          :error
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          # a
-          false ->
-            :error
-          # b
-          true ->
-            :ok
-        end
-        """,
-        """
-        if foo do
-          # b
-          :ok
-        else
-          # a
-          :error
-        end
-        """
-      )
-
-      assert_style(
-        """
-        case foo do
-          # a
-          false -> :error
-          # b
-          true -> :ok
-        end
-        """,
-        """
-        if foo do
-          # b
-          :ok
-        else
-          # a
-          :error
-        end
-        """
-      )
-    end
-
-    test "complex comments" do
-      assert_style(
-        """
-        case foo do
-          false ->
-            #a
-            actual(code)
-
-            #b
-            if foo do
-              #c
-              doing_stuff()
-              #d
-            end
-
-            #e
-            :ok
-          true ->
-            #f
-            Logger.warning("it's false")
-
-            if 1 do
-              # g
-              :yay
-            else
-              # h
-              :ohno
-            end
-
-            # i
-            nil
-        end
-        """,
-        """
-        if foo do
-          # f
-          Logger.warning("it's false")
-
-          if 1 do
-            # g
-            :yay
-          else
-            # h
-            :ohno
-          end
-
-          # i
-          nil
-        else
-          # a
-          actual(code)
-
-          # b
-          if foo do
-            # c
-            doing_stuff()
-            # d
-          end
-
-          # e
-          :ok
-        end
-        """
-      )
-    end
-  end
-
   describe "with statements" do
     test "replacement due to no (or all removed) arrows" do
       assert_style(
@@ -480,7 +249,7 @@ defmodule Styler.Style.BlocksTest do
       )
     end
 
-    test "transforms a `with` all the way to an `if` if necessary" do
+    test "transforms an unnecessary `with` to `case`" do
       # with a preroll
       assert_style(
         """
@@ -494,10 +263,9 @@ defmodule Styler.Style.BlocksTest do
         """
         foo = bar
 
-        if bop do
-          :ok
-        else
-          :error
+        case bop do
+          true -> :ok
+          _ -> :error
         end
         """
       )
@@ -512,10 +280,9 @@ defmodule Styler.Style.BlocksTest do
         end
         """,
         """
-        if bop do
-          :ok
-        else
-          :error
+        case bop do
+          true -> :ok
+          _ -> :error
         end
         """
       )
@@ -530,11 +297,13 @@ defmodule Styler.Style.BlocksTest do
         end
         """,
         """
-        if bop do
-          foo = bar
-          :ok
-        else
-          :error
+        case bop do
+          true ->
+            foo = bar
+            :ok
+
+          _ ->
+            :error
         end
         """
       )


### PR DESCRIPTION
As much as the `case` statement for pure boolean checking is generally good style, rolling out this change across a large codebase increases the risk of bugs due to the difference in behavior between `if` and `case` when the value is not a boolean.