### PR TITLE
Disable `if not` => `unless` rule

### DIFF
--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -178,10 +178,6 @@ defmodule Styler.Style.Blocks do
       [negator, [{do_, do_body}, {else_, else_body}]] when is_negator(negator) ->
         zipper |> Zipper.replace({:if, m, [invert(negator), [{do_, else_body}, {else_, do_body}]]}) |> run(ctx)
 
-      # if not x, do: y => unless x, do: y
-      [negator, [do_block]] when is_negator(negator) ->
-        zipper |> Zipper.replace({:unless, m, [invert(negator), [do_block]]}) |> run(ctx)
-
       [head, [do_, else_]] ->
         if Style.max_line(do_) > Style.max_line(else_) do
           # we inverted the if/else blocks of this `if` statement in a previous pass (due to negators or unless)

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -773,12 +773,6 @@ defmodule Styler.Style.BlocksTest do
   end
 
   describe "if/unless" do
-    test "if not => unless" do
-      assert_style("if not x, do: y", "unless x, do: y")
-      assert_style("if !x, do: y", "unless x, do: y")
-      assert_style("if !!x, do: y", "if x, do: y")
-    end
-
     test "Credo.Check.Refactor.UnlessWithElse" do
       for negator <- ["!", "not "] do
         assert_style(
@@ -950,8 +944,6 @@ defmodule Styler.Style.BlocksTest do
         end
         """
       )
-
-      assert_style("if not (a != b), do: c", "if a == b, do: c")
     end
 
     test "comments and flips" do


### PR DESCRIPTION
Our team finds that the `if not` to `unless` rule sometimes actually makes things a little bit harder to understand. This PR removes the rule, allowing us to instead decide on a case-by-case basis. The main downside to this rule is that we lose the awesome double-negative conversion that Styler does. Perhaps in a future PR we can find a way to add this back.