### PR TITLE
Keep `if`s with `else: nil` (explicit is better) and format the library

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ Other ways Styler can change your program:
 - [config file sorting](https://hexdocs.pm/styler/mix_configs.html#this-can-break-your-program)
 - and likely other ways. stay safe out there!
 
->>>>>>> upstream/main
 ## Thanks & Inspiration
 
 ### [Sourceror](https://github.com/doorgan/sourceror/)

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -143,6 +143,8 @@ defmodule Styler.Style.Blocks do
       [head, [do_block, {_, {:__block__, _, []}}]] ->
         {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}
 
+      # We like keeping `else: nil` even if it's the same effect due to the explicitness.
+      #
       # drop `else: nil`
       # [head, [do_block, {_, {:__block__, _, [nil]}}]] ->
       #   {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}

--- a/lib/style/blocks.ex
+++ b/lib/style/blocks.ex
@@ -25,10 +25,10 @@ defmodule Styler.Style.Blocks do
   * Credo.Check.Refactor.WithClauses
   """
 
-  @behaviour Styler.Style
-
   alias Styler.Style
   alias Styler.Zipper
+
+  @behaviour Styler.Style
 
   defguardp is_negator(n) when elem(n, 0) in [:!, :not, :!=, :!==]
 
@@ -144,8 +144,8 @@ defmodule Styler.Style.Blocks do
         {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}
 
       # drop `else: nil`
-      [head, [do_block, {_, {:__block__, _, [nil]}}]] ->
-        {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}
+      # [head, [do_block, {_, {:__block__, _, [nil]}}]] ->
+      #   {:cont, Zipper.replace(zipper, {:if, m, [head, [do_block]]}), ctx}
 
       [head, [do_, else_]] ->
         if Style.max_line(do_) > Style.max_line(else_) do

--- a/lib/style/comment_directives.ex
+++ b/lib/style/comment_directives.ex
@@ -15,10 +15,10 @@ defmodule Styler.Style.CommentDirectives do
   `# styler:sort` maintains sorting of wordlists (by string comparison) and lists (string comparison of code representation)
   """
 
-  @behaviour Styler.Style
-
   alias Styler.Style
   alias Styler.Zipper
+
+  @behaviour Styler.Style
 
   def run(zipper, ctx) do
     {zipper, comments} =

--- a/lib/zipper.ex
+++ b/lib/zipper.ex
@@ -178,7 +178,7 @@ defmodule Styler.Zipper do
   """
   @spec prepend_siblings(zipper, [tree]) :: zipper
   def prepend_siblings({node, nil}, siblings), do: {:__block__, [], siblings ++ [node]} |> zip() |> down() |> rightmost()
-  def prepend_siblings({tree, {l, p, r}}, siblings), do: {tree, {Enum.reverse(siblings, l), p , r}}
+  def prepend_siblings({tree, {l, p, r}}, siblings), do: {tree, {Enum.reverse(siblings, l), p, r}}
 
   @doc """
   Inserts the item as the right sibling of the node at this zipper, without

--- a/test/style/blocks_test.exs
+++ b/test/style/blocks_test.exs
@@ -734,12 +734,14 @@ defmodule Styler.Style.BlocksTest do
   end
 
   describe "if" do
-    test "drops else nil" do
-      assert_style("if a, do: b, else: nil", "if a, do: b")
+    test "keeps else nil" do
+      assert_style("if a, do: b, else: nil", "if a, do: b, else: nil")
 
       assert_style("if a do b else nil end", """
       if a do
         b
+      else
+        nil
       end
       """)
 

--- a/test/style/comment_directives_test.exs
+++ b/test/style/comment_directives_test.exs
@@ -10,6 +10,7 @@
 
 defmodule Styler.Style.CommentDirectivesTest do
   @moduledoc false
+
   use Styler.StyleCase, async: true
 
   describe "sort" do

--- a/test/zipper_test.exs
+++ b/test/zipper_test.exs
@@ -70,7 +70,7 @@ defmodule StylerTest.ZipperTest do
                {1, {[], {{:foo, [], [1, 2]}, nil}, [2]}}
 
       assert {{:., [], [:a, :b]}, [], [1, 2]} |> Zipper.zip() |> Zipper.down() ==
-               {{:., [], [:a, :b]}, {[],{{{:., [], [:a, :b]}, [], [1, 2]}, nil}, [1, 2]}}
+               {{:., [], [:a, :b]}, {[], {{{:., [], [:a, :b]}, [], [1, 2]}, nil}, [1, 2]}}
     end
   end
 


### PR DESCRIPTION
- Keep `if`s with `else nil` statements for explicitness.
- Formats the library.
- Removes a missed merge conflict line.