### PR TITLE
Don't lift require aliases due to our ordering rules

### DIFF
--- a/lib/style/module_directives.ex
+++ b/lib/style/module_directives.ex
@@ -433,11 +433,12 @@ defmodule Styler.Style.ModuleDirectives do
 
   defp apply_aliases(acc, inverted_env) when map_size(inverted_env) == 0, do: acc
 
-  defp apply_aliases(%{require: requires, nondirectives: nondirectives, alias_env: alias_env} = acc, inverted_env) do
-    # applying aliases to requires can change their ordering again
-    requires = requires |> apply_aliases(inverted_env, alias_env) |> sort()
+  defp apply_aliases(%{nondirectives: nondirectives, alias_env: alias_env} = acc, inverted_env) do
+    # Requires are intentionally left alone: they sort above aliases in strict layout,
+    # so shortening `require Foo.Bar` to `require Bar` would reference an alias declared
+    # below it (broken Elixir).
     nondirectives = apply_aliases(nondirectives, inverted_env, alias_env)
-    %{acc | require: requires, nondirectives: nondirectives}
+    %{acc | nondirectives: nondirectives}
   end
 
   # applies the aliases withi `to_as` across the given ast

--- a/test/style/module_directives/alias_lifting_test.exs
+++ b/test/style/module_directives/alias_lifting_test.exs
@@ -176,7 +176,7 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
 
         import A.B.C
 
-        require C
+        require A.B.C
 
         alias A.B.C
 
@@ -216,7 +216,9 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
     )
   end
 
-  test "re-sorts requires after lifting" do
+  test "lifting does not rewrite require directives" do
+    # Requires sort above aliases, so a `require A.B.C` cannot be shortened to `require C` - at that point in the file,
+    # `C` isn't aliased yet.
     assert_style(
       """
       defmodule A do
@@ -224,16 +226,49 @@ defmodule Styler.Style.ModuleDirectives.AliasLiftingTest do
         require B
 
         A.B.C.foo()
+        A.B.C.foo()
       end
       """,
       """
       defmodule A do
+        require A.B.C
         require B
-        require C
 
         alias A.B.C
 
         C.foo()
+        C.foo()
+      end
+      """
+    )
+  end
+
+  test "lifting via a require sighting does not rewrite the require itself" do
+    # Regression test: one require + one nondirective use of the same FQDN used to
+    # produce a `require Baz` ordered above its `alias Foo.Bar.Baz` (broken Elixir).
+    assert_style(
+      """
+      defmodule Foo do
+        @moduledoc false
+
+        require Foo.Bar.Baz
+
+        def go do
+          Foo.Bar.Baz.go()
+        end
+      end
+      """,
+      """
+      defmodule Foo do
+        @moduledoc false
+
+        require Foo.Bar.Baz
+
+        alias Foo.Bar.Baz
+
+        def go do
+          Baz.go()
+        end
       end
       """
     )

--- a/test/style/module_directives_test.exs
+++ b/test/style/module_directives_test.exs
@@ -294,7 +294,7 @@ defmodule Styler.Style.ModuleDirectivesTest do
         alias A.A
         """,
         """
-        require A
+        require A.A
         require A.C
 
         alias A.A


### PR DESCRIPTION
Our module directive ordering is slightly different than upstream Styler. We put `require`s before `alias` always. This means that any alias lifting that also rewrites `require` to use the alias will cause compilation to fail. To fix this, we:

- Don't rewrite `require` modules. If they're written fully qualified, leave them be.
- Don't count `require` fully qualified module calls against our fully qualified module limit before lifting the alias.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk formatter change: it narrows alias-application behavior to avoid generating invalid `require` directives under the project’s strict ordering rules. Main impact is changed formatted output for modules that previously had `require` shortened via lifted aliases.
> 
> **Overview**
> Prevents alias lifting/alias application from shortening `require Foo.Bar` into `require Bar`, since `require`s are ordered above `alias` and would otherwise reference an alias declared later (invalid Elixir).
> 
> Updates expectations and adds regression coverage to ensure `require` stays fully-qualified while non-directive usages are still rewritten to the lifted alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b063690f99703468299f9989fd47a39b20f95db8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->